### PR TITLE
Maxlength for image and video descriptions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "drupal/disable_language": "1.x-dev",
         "drupal/entity_browser": "^2.5",
         "drupal/facets": "^1.4",
+        "drupal/maxlength": "1.x-dev",
         "drupal/metatag": "1.x-dev",
         "drupal/oembed_providers": "^1.0",
         "drupal/paragraphs": "1.x-dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d2470207df8aaf3847eeeca8427822d9",
+    "content-hash": "db586cba5c6e588cf51dd31a0964a036",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1795,7 +1795,8 @@
                         "[web-root]/profiles/README.txt": "assets/scaffold/files/profiles.README.txt",
                         "[web-root]/themes/README.txt": "assets/scaffold/files/themes.README.txt"
                     }
-                }
+                },
+                "patches_applied": []
             },
             "autoload": {
                 "psr-4": {
@@ -2276,6 +2277,108 @@
                 "irc": "irc://irc.freenode.org/drupal-search-api"
             },
             "time": "2020-04-09T07:59:51+00:00"
+        },
+        {
+            "name": "drupal/maxlength",
+            "version": "dev-1.x",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/maxlength.git",
+                "reference": "1d04e2eaa17be01347c339ce09602071cd840783"
+            },
+            "require": {
+                "drupal/core": "^8.8 || ^9"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-1.0-beta5+1-dev",
+                    "datestamp": "1580312371",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Dev releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Aron Novak",
+                    "homepage": "https://www.drupal.org/user/61864"
+                },
+                {
+                    "name": "Schnitzel",
+                    "homepage": "https://www.drupal.org/user/643820"
+                },
+                {
+                    "name": "a_c_m",
+                    "homepage": "https://www.drupal.org/user/195063"
+                },
+                {
+                    "name": "barneytech",
+                    "homepage": "https://www.drupal.org/user/669922"
+                },
+                {
+                    "name": "claudiu_cristea",
+                    "homepage": "https://www.drupal.org/user/2623935"
+                },
+                {
+                    "name": "dawehner",
+                    "homepage": "https://www.drupal.org/user/99340"
+                },
+                {
+                    "name": "derhasi",
+                    "homepage": "https://www.drupal.org/user/83474"
+                },
+                {
+                    "name": "frjo",
+                    "homepage": "https://www.drupal.org/user/5546"
+                },
+                {
+                    "name": "hefox",
+                    "homepage": "https://www.drupal.org/user/426416"
+                },
+                {
+                    "name": "jm.federico",
+                    "homepage": "https://www.drupal.org/user/509892"
+                },
+                {
+                    "name": "k4v",
+                    "homepage": "https://www.drupal.org/user/744246"
+                },
+                {
+                    "name": "mariano73",
+                    "homepage": "https://www.drupal.org/user/1324866"
+                },
+                {
+                    "name": "mariuss",
+                    "homepage": "https://www.drupal.org/user/28539"
+                },
+                {
+                    "name": "sanduhrs",
+                    "homepage": "https://www.drupal.org/user/28074"
+                },
+                {
+                    "name": "vasi1186",
+                    "homepage": "https://www.drupal.org/user/342104"
+                },
+                {
+                    "name": "webiator GmbH",
+                    "homepage": "https://www.drupal.org/user/2390554"
+                }
+            ],
+            "description": "Limit the number of characters in textfields and textareas and shows the amount of characters left.",
+            "homepage": "https://www.drupal.org/project/maxlength",
+            "support": {
+                "source": "https://git.drupalcode.org/project/maxlength"
+            },
+            "time": "2020-04-11T06:46:46+00:00"
         },
         {
             "name": "drupal/metatag",
@@ -6863,6 +6966,7 @@
     "minimum-stability": "dev",
     "stability-flags": {
         "drupal/disable_language": 20,
+        "drupal/maxlength": 20,
         "drupal/metatag": 20,
         "drupal/paragraphs": 20,
         "drupal/viewsreference": 20

--- a/config/sync/core.entity_form_display.node.image.default.yml
+++ b/config/sync/core.entity_form_display.node.image.default.yml
@@ -12,6 +12,7 @@ dependencies:
     - workflows.workflow.content_workflow
   module:
     - content_moderation
+    - maxlength
     - media_library
     - path
     - text
@@ -31,7 +32,12 @@ content:
     settings:
       rows: 5
       placeholder: ''
-    third_party_settings: {  }
+    third_party_settings:
+      maxlength:
+        maxlength_js: 1000
+        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_enforce: true
+        maxlength_js_truncate_html: true
     type: text_textarea
     region: content
   field_image:

--- a/config/sync/core.entity_form_display.node.video.default.yml
+++ b/config/sync/core.entity_form_display.node.video.default.yml
@@ -13,6 +13,7 @@ dependencies:
     - workflows.workflow.content_workflow
   module:
     - content_moderation
+    - maxlength
     - media_library
     - path
     - text
@@ -39,7 +40,12 @@ content:
     settings:
       rows: 5
       placeholder: ''
-    third_party_settings: {  }
+    third_party_settings:
+      maxlength:
+        maxlength_js: 1000
+        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_enforce: true
+        maxlength_js_truncate_html: true
     type: text_textarea
     region: content
   field_rights:

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -35,6 +35,7 @@ module:
   layout_discovery: 0
   link: 0
   locale: 0
+  maxlength: 0
   media: 0
   media_library: 0
   menu_link_content: 0


### PR DESCRIPTION
Fixes #30.

##### Pull request details

- Adds maxlength
- Configured for descriptions

TBD

- Set to 1000 characters with force truncate
- Applied to default form only -> perhaps discuss the approach for default / full form - same for the display (this one is not related to the issue though).

To be fixed in a follow up: duplication of the ui element, possibly a known issue / regression of https://www.drupal.org/project/maxlength/issues/2925259 or https://www.drupal.org/project/maxlength/issues/3076581
![Screenshot 2020-05-24 at 18 01 38](https://user-images.githubusercontent.com/525003/82758907-b520fc00-9de9-11ea-9635-8e47a554913f.png)

This is not the case on the frontend so should be good enough for the mvp.
![Screenshot 2020-05-27 at 12 08 38](https://user-images.githubusercontent.com/525003/83006635-d44ea200-a012-11ea-9da3-3b2aded71a0a.png)
