### PR TITLE
Frontend node types description

### DIFF
--- a/config/sync/field.field.node.event.field_coc_agreement.yml
+++ b/config/sync/field.field.node.event.field_coc_agreement.yml
@@ -10,7 +10,7 @@ field_name: field_coc_agreement
 entity_type: node
 bundle: event
 label: 'The event I''m hosting complies with the Drupal Code of Conduct'
-description: 'You can check the Drupal Code of Conduct on https://www.drupal.org/dcoc'
+description: 'You can check the <a href="https://www.drupal.org/dcoc" target="_blank">Drupal Code of Conduct</a>.'
 required: true
 translatable: false
 default_value:

--- a/config/sync/field.field.node.image.field_coc_agreement.yml
+++ b/config/sync/field.field.node.image.field_coc_agreement.yml
@@ -10,7 +10,7 @@ field_name: field_coc_agreement
 entity_type: node
 bundle: image
 label: 'My uploaded content complies with the Drupal Code of Conduct'
-description: 'You can check the Drupal Code of Conduct on https://www.drupal.org/dcoc'
+description: 'You can check the <a href="https://www.drupal.org/dcoc" target="_blank">Drupal Code of Conduct</a>.'
 required: true
 translatable: false
 default_value:

--- a/config/sync/field.field.node.video.field_coc_agreement.yml
+++ b/config/sync/field.field.node.video.field_coc_agreement.yml
@@ -10,7 +10,7 @@ field_name: field_coc_agreement
 entity_type: node
 bundle: video
 label: 'My uploaded content complies with the Drupal Code of Conduct'
-description: 'You can check the Drupal Code of Conduct on https://www.drupal.org/dcoc'
+description: 'You can check the <a href="https://www.drupal.org/dcoc" target="_blank">Drupal Code of Conduct</a>.'
 required: true
 translatable: false
 default_value:

--- a/config/sync/locale.settings.yml
+++ b/config/sync/locale.settings.yml
@@ -1,5 +1,5 @@
 cache_strings: true
-translate_english: false
+translate_english: true
 javascript:
   directory: languages
 translation:

--- a/web/modules/custom/content_submission/content_submission.module
+++ b/web/modules/custom/content_submission/content_submission.module
@@ -11,9 +11,7 @@
 function content_submission_theme() {
   return [
     'add_content' => [
-      'variables' => [
-        'content_types' => NULL
-      ],
+      'variables' => [],
       'render element' => 'children',
     ],
     'user_links' => [

--- a/web/modules/custom/content_submission/src/Plugin/Block/AddContentBlock.php
+++ b/web/modules/custom/content_submission/src/Plugin/Block/AddContentBlock.php
@@ -54,50 +54,14 @@ class AddContentBlock extends BlockBase implements ContainerFactoryPluginInterfa
   }
 
   /**
-   * Returns a render array of the node add list.
-   *
-   * @return array
-   */
-  private function getNodeTypeList() {
-    $build = [
-      '#theme' => 'node_add_list',
-      '#cache' => [
-        'tags' => $this->entityTypeManager->getDefinition('node_type')->getListCacheTags(),
-      ],
-    ];
-    $content = [];
-    // Only use node types the user has access to.
-    foreach ($this->entityTypeManager->getStorage('node_type')->loadMultiple() as $type) {
-      $access = $this->entityTypeManager->getAccessControlHandler('node')->createAccess($type->id(), NULL, [], TRUE);
-      if ($access->isAllowed()) {
-        $content[$type->id()] = $type;
-      }
-      $this->renderer->addCacheableDependency($build, $access);
-    }
-    $build['#content'] = $content;
-    return $build;
-  }
-
-  private function getLinkFromRoute($label, $route, $classes = []) {
-    $url = Url::fromRoute($route);
-    if (!empty($classes)) {
-      $options = [
-        'attributes' => [
-          'class' => $classes
-        ],
-      ];
-    }
-    $url->setOptions($options);
-    return Link::fromTextAndUrl($label, $url)->toRenderable();
-  }
-
-  /**
    * {@inheritdoc}
    */
   public function build() {
     $build = [];
     if ($this->currentUser->isAuthenticated()) {
-      $build = $this->getNodeTypeList();
+      $build = [
+        '#theme' => 'add_content',
+      ];
     }
     else {
       $buttonClasses = [

--- a/web/modules/custom/content_submission/templates/add-content.html.twig
+++ b/web/modules/custom/content_submission/templates/add-content.html.twig
@@ -9,10 +9,58 @@
 */
 #}
 {% set classes = [
-    'clear-both',
+  'clear-both',
+] %}
+{% set buttonClasses = [
+  'text-center',
+  'block',
+  'border',
+  'border-blue-500',
+  'py-2',
+  'px-4',
+  'bg-blue-500',
+  'hover:bg-blue-600',
+  'text-white',
+  'text-xl',
+  'font-sans',
+  'font-bold',
+  'align-bottom',
 ] %}
 <div{{ attributes.addClass(classes) }}>
-    {% for content_type in content_types %}
-        <p>{{content_type}}</p>
-    {% endfor %}
+  <div class="flex mb-4 w-full flex-wrap">
+    <div class="flex flex-col md:w-1/2 lg:w-1/3 px-4 mb-4">
+      <h2>{% trans %}Video{% endtrans %}</h2>
+      <div class="flex-grow">
+        {% trans %}
+          <p>You can record your video using a laptop or a phone. When using a laptop, you can use Zoom (just a suggestion, you can use any other tool as well) and can use virtual background. For the virtual background you can choose wallpapers from <a href="https://www.behance.net/gallery/97519115/Drupal-Fan-Art">Drupal Fan Art</a></p>
+          <p>When using a phone, it is recommended to record the video in landscape mode.</p>
+          <p>Be as creative as you can be, we would not like to limit your ideas by putting any time or content restrictions. Only take into account that this platform is by the community, for the community :)</p>
+        {% endtrans %}
+      </div>
+      <a{{ attributes.addClass(buttonClasses) }} href="{{ path('node.add', {'node_type': 'video'}) }}">{% trans %}Add Video{% endtrans %}</a>
+    </div>
+    <div class="flex flex-col md:w-1/2 lg:w-1/3 px-4 mb-4">
+      <h2>{% trans %}Photo{% endtrans %}</h2>
+      <div class="flex-grow">
+        {% trans %}
+          <p>There are so many memories we all have being a part of the Drupal community, let’s show that to each other. It's time to take out the old Drupal t-shirt, folks!</p>
+          <p>Which event is the most close to your heart? Do you remember any significant instance?</p>
+          <p>Let us know through your selfies in that t-shirt of yours ;)</p>
+        {% endtrans %}
+      </div>
+      <a{{ attributes.addClass(buttonClasses) }} href="{{ path('node.add', {'node_type': 'image'}) }}">{% trans %}Add Photo{% endtrans %}</a>
+    </div>
+    <div class="flex flex-col md:w-1/2 lg:w-1/3 px-4 mb-4">
+      <h2>{% trans %}Event{% endtrans %}</h2>
+      <div class="flex-grow">
+        {% trans %}
+          <p>Host an online event! With regards to the current happenings, probably an online party is the best way to bring your fellow Drupalistas together, and share virtual cheers in front of the computer screens.</p>
+          <p>With the help of Zoom, Google Meet or Jitsi (or else) create an event, and add the link to it. Don't forget to set the date and time too!</p>
+          <p>It is nice to tell your future guests if it's a thematic event or more like a hallway discussion :)</p>
+          <p>And then when the time comes, have fun!</p>
+        {% endtrans %}
+      </div>
+      <a{{ attributes.addClass(buttonClasses) }} href="{{ path('node.add', {'node_type': 'event'}) }}">{% trans %}Add Event{% endtrans %}</a>
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
The backend node type description is different on the frontend. Add the description to submit a content per node type with layout in 3 columns.

![Screenshot 2020-05-28 at 23 33 39](https://user-images.githubusercontent.com/525003/83198683-f72aa480-a13f-11ea-8ff9-9ed04286b6dc.png)

As the content might not change that often the text is embedded in the template and English has been set as editable via the interface translation UI.

There are several other options: we could make use of columns based paragraphs or blocks wrapped in a section with layout builder, but then we need to add the per role context (anonymous = register/login, authenticated = these texts).
Keeping it simple for now.

Also add link to the Drupal CoC in the field description