### PR TITLE
Sticky footer for video teaser

### DIFF
--- a/web/themes/custom/drupal_celebrations/templates/components/node/node--image--teaser.html.twig
+++ b/web/themes/custom/drupal_celebrations/templates/components/node/node--image--teaser.html.twig
@@ -102,11 +102,11 @@
       {% endif %}
       <div class="mt-2 text-gray-700 text-base">
         {{ content | without('field_image', 'field_description', 'field_image_category') }}
-        {% if display_submitted and author_card %}
-          <footer class="node__meta">
-            {{ author_card }}
-          </footer>
-        {% endif %}
       </div>
+      {% if display_submitted and author_card %}
+        <footer class="node__meta">
+          {{ author_card }}
+        </footer>
+      {% endif %}
   </div>
 </article>

--- a/web/themes/custom/drupal_celebrations/templates/components/node/node--video--teaser.html.twig
+++ b/web/themes/custom/drupal_celebrations/templates/components/node/node--video--teaser.html.twig
@@ -88,7 +88,7 @@
 
   <a href="{{ url }}" rel="bookmark">{{ content.field_video }}</a>
 
-  <div class="px-6 py-4 flex-1">
+  <div class="px-6 mt-4 flex-1">
   {% if content.field_video_category %}
     {{ content.field_video_category }}
   {% endif %}
@@ -104,7 +104,7 @@
     </div>
   </div>
   {% if display_submitted and author_card %}
-    <footer class="node__meta px-6 py-4">
+    <footer class="node__meta px-6 mb-4">
       {{ author_card }}
     </footer>
   {% endif %}

--- a/web/themes/custom/drupal_celebrations/templates/components/node/node--video--teaser.html.twig
+++ b/web/themes/custom/drupal_celebrations/templates/components/node/node--video--teaser.html.twig
@@ -78,6 +78,9 @@
     'overflow-hidden',
     'bg-white',
     'shadow-md',
+    'flex',
+    'flex-col',
+    'h-full',
   ]
 %}
 
@@ -85,7 +88,7 @@
 
   <a href="{{ url }}" rel="bookmark">{{ content.field_video }}</a>
 
-  <div class="px-6 py-4">
+  <div class="px-6 py-4 flex-1">
   {% if content.field_video_category %}
     {{ content.field_video_category }}
   {% endif %}
@@ -98,12 +101,12 @@
     {% endif %}
     <div class="text-gray-700 text-base">
       {{ content | without('field_video', 'field_video_category') }}
-      {% if display_submitted and author_card %}
-        <footer class="node__meta">
-          {{ author_card }}
-        </footer>
-      {% endif %}
     </div>
   </div>
+  {% if display_submitted and author_card %}
+    <footer class="node__meta px-6 py-4">
+      {{ author_card }}
+    </footer>
+  {% endif %}
 
 </article>


### PR DESCRIPTION
As the description can have a variation of several lines (or not be displayed), the author meta in the article footer could be sticky so we end up with this result. We could also have a different text color than the description for this footer, to distinguish it from the description (not certain about that though).
![Screenshot 2020-05-29 at 22 29 36](https://user-images.githubusercontent.com/525003/83302606-f3f4ee80-a1fb-11ea-89a8-e861e67ff368.png)

Instead of
![Screenshot 2020-05-29 at 22 25 30](https://user-images.githubusercontent.com/525003/83302632-fd7e5680-a1fb-11ea-90c9-e2771152cf1b.png)

As images does not have this variation on teaser it is not needed there.

See #35 