### PR TITLE
Set Search API tag based Celebrations views caching, set site wide cache

### DIFF
--- a/config/sync/system.performance.yml
+++ b/config/sync/system.performance.yml
@@ -1,6 +1,6 @@
 cache:
   page:
-    max_age: 0
+    max_age: 10800
 css:
   preprocess: true
   gzip: true

--- a/config/sync/views.view.celebrations.yml
+++ b/config/sync/views.view.celebrations.yml
@@ -28,7 +28,7 @@ display:
         options:
           perm: 'access content'
       cache:
-        type: tag
+        type: search_api_tag
         options: {  }
       query:
         type: views_query
@@ -548,7 +548,8 @@ display:
         groups:
           1: AND
       cache:
-        type: none
+        type: search_api_tag
+        options: {  }
       use_more: true
       use_more_always: false
       use_more_text: 'All photos'
@@ -661,7 +662,8 @@ display:
         groups:
           1: AND
       cache:
-        type: none
+        type: search_api_tag
+        options: {  }
     cache_metadata:
       max-age: -1
       contexts:
@@ -959,7 +961,8 @@ display:
         groups:
           1: AND
       cache:
-        type: none
+        type: search_api_tag
+        options: {  }
     cache_metadata:
       max-age: -1
       contexts:
@@ -1072,7 +1075,8 @@ display:
         groups:
           1: AND
       cache:
-        type: none
+        type: search_api_tag
+        options: {  }
       use_more: true
       use_more_always: false
       use_more_text: 'All videos'


### PR DESCRIPTION
Fixes the Celebration views caching by making use of Search API tag based cache invalidation (which might be better than time based caching as it will display the image/video once published).
Also set the site wide cache to 3 hours (it was set to 0).

Testing
- Publish a new video or image
- Visit the front, videos and images pages (based on Celebrations views display) as anonymous user, displays are being updated without the need of clearing the caches manually.