### PR TITLE
View own media entities in the media library

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -43,6 +43,7 @@ module:
   maxlength: 0
   media: 0
   media_library: 0
+  media_library_view_own: 0
   menu_link_content: 0
   menu_ui: 0
   metatag: 0

--- a/web/modules/custom/media_library_view_own/media_library_view_own.info.yml
+++ b/web/modules/custom/media_library_view_own/media_library_view_own.info.yml
@@ -1,0 +1,7 @@
+name: 'Media library view own'
+type: module
+description: 'View own Media entities only while using the Media library if the current user does not have the 'access media overview' permission.'
+core_version_requirement: ^8.8.0 || ^9.0
+package: 'Media'
+dependencies:
+  - drupal:media_library

--- a/web/modules/custom/media_library_view_own/media_library_view_own.info.yml
+++ b/web/modules/custom/media_library_view_own/media_library_view_own.info.yml
@@ -1,6 +1,6 @@
 name: 'Media library view own'
 type: module
-description: 'View own Media entities only while using the Media library if the current user does not have the 'access media overview' permission.'
+description: 'View own Media entities only while using the Media library if the current user does not have the access media overview permission.'
 core_version_requirement: ^8.8.0 || ^9.0
 package: 'Media'
 dependencies:

--- a/web/modules/custom/media_library_view_own/media_library_view_own.module
+++ b/web/modules/custom/media_library_view_own/media_library_view_own.module
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @file
+ * Contains media_library_view_own.module.
+ */
+
+use Drupal\Core\Database\Query\Condition;
+use Drupal\views\ViewExecutable;
+use Drupal\views\Plugin\views\query\QueryPluginBase;
+
+/**
+ * Implements hook_views_query_alter().
+ */
+function media_library_view_own_views_query_alter(ViewExecutable $view, QueryPluginBase $query) {
+  if ($view->id() === 'media_library') {
+    $currentUser = \Drupal::currentUser();
+    if (!$currentUser->hasPermission('access media overview')) {
+      $and = new Condition('AND');
+      $query->addWhere(
+        'conditions',
+        $and->condition('media_field_data.uid', $currentUser->id())
+      );
+    }
+  }
+}

--- a/web/modules/custom/media_library_view_own/media_library_view_own.views_execution.inc
+++ b/web/modules/custom/media_library_view_own/media_library_view_own.views_execution.inc
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains media_library_view_own.module.
- */
-
 use Drupal\Core\Database\Query\Condition;
 use Drupal\views\ViewExecutable;
 use Drupal\views\Plugin\views\query\QueryPluginBase;
@@ -15,7 +10,10 @@ use Drupal\views\Plugin\views\query\QueryPluginBase;
 function media_library_view_own_views_query_alter(ViewExecutable $view, QueryPluginBase $query) {
   if ($view->id() === 'media_library') {
     $currentUser = \Drupal::currentUser();
-    if (!$currentUser->hasPermission('access media overview')) {
+    if (
+      $currentUser->isAuthenticated() &&
+      !$currentUser->hasPermission('access media overview')
+    ) {
       $and = new Condition('AND');
       $query->addWhere(
         'conditions',
@@ -24,3 +22,4 @@ function media_library_view_own_views_query_alter(ViewExecutable $view, QueryPlu
     }
   }
 }
+


### PR DESCRIPTION
FIxes #64 

View own Media entities only, while using the Media library, if the current user does not have the 'access media overview' permission.

This could be used as a quick fix until we have validated #62.