### PR TITLE
Upsize storage

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -30,7 +30,7 @@ dependencies:
         yarn: "*"
 
 # The size of the persistent disk of the application (in MB).
-disk: 2048
+disk: 11048
 
 # The 'mounts' describe writable, persistent filesystem mounts in the application.
 mounts:

--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -5,7 +5,7 @@
 
 db:
     type: mariadb:10.4
-    disk: 2048
+    disk: 1048
 
 cache:
     type: redis:5.0


### PR DESCRIPTION
The site is triggering warnings that disk storage is running low. This extends storage for the app and MySQL. Platform.sh has already added the requisite storage to the project plan. 